### PR TITLE
Add links to everynoise playlists

### DIFF
--- a/genre.js
+++ b/genre.js
@@ -17,7 +17,12 @@
     return res.genres.slice(0, 3) // Only keep the first 3 genres
   };
 
-  const fetchPlaylist = async (genre) => {
+  /**
+   * Fetch playlist from The Sound of Spotify for a given genre
+   * @param {String} genre
+   * @return {String|null}
+   */
+  const fetchSoundOfSpotifyPlaylist = async (genre) => {
     const query = encodeURIComponent(`The Sound of ${genre}`);
     // Check localStorage for playlist
     const cached = localStorage.getItem(`everynoise:${query}`);
@@ -33,7 +38,7 @@
         localStorage.setItem(`everynoise:${genre}`, item.uri);
         return item.uri
       }
-     }
+    }
     return null;
   };
 
@@ -83,7 +88,7 @@
 
           for (const i in genres) {
             let element;
-            const uri = await fetchPlaylist(genres[i]);
+            const uri = await fetchSoundOfSpotifyPlaylist(genres[i]);
             if (uri !== null) {
               element = document.createElement('a');
               element.innerHTML = genres[i];
@@ -104,7 +109,7 @@
           infoContainer = document.querySelector('div.main-trackInfo-container');
           if(!infoContainer) cleanInjection();
           infoContainer.appendChild(genreContainer);
-          
+
         }
       } else {
         cleanInjection();


### PR DESCRIPTION
This is a very naive implementation of the idea mentioned in #2, adding links to the everynoise genre playlists.

As far as I can tell you can't request the playlist link from everynoise.com directly (please let me know if I'm mistaken here), so this workaround uses the spotify `/search/` endpoint to look up the playlist by name. Results are checked to make sure the owner is the "Sounds of Spotify" account and the playlist name matches the correct genre. Successfully obtained playlists are stored in local storage.

The extra requests lead to slightly longer load times. A possible improvement would be to display the genres as soon as they are obtained and insert the links retroactively.